### PR TITLE
Fix: Importation errors

### DIFF
--- a/rag_assistant/gradio_ui.py
+++ b/rag_assistant/gradio_ui.py
@@ -2,9 +2,9 @@ from typing import Dict
 import gradio as gr
 
 from rag_assistant.RagAssistant import RagAssistant
-from gradio_tabs.chat_tab import ChatTab
-from gradio_tabs.document_tab import DocumentTab
-from gradio_tabs.document_edits_tab import DocumentEditsTab
+from rag_assistant.gradio_tabs.chat_tab import ChatTab
+from rag_assistant.gradio_tabs.document_tab import DocumentTab
+from rag_assistant.gradio_tabs.document_edits_tab import DocumentEditsTab
 
 
 class GradioUI:

--- a/rag_assistant/main.py
+++ b/rag_assistant/main.py
@@ -1,5 +1,5 @@
 import argparse
-from gradio_ui import GradioUI
+from rag_assistant.gradio_ui import GradioUI
 from rag_assistant.utils.configure import (
     read_config_file,
     generate_config_json,

--- a/rag_assistant/utils/configure.py
+++ b/rag_assistant/utils/configure.py
@@ -1,10 +1,10 @@
-from rag_assistant.RagAssistant import RagAssistant
 import argparse
 from typing import Dict, Any
 import os
 import yaml
 import json
 import importlib.resources as pkg_resources
+from rag_assistant.RagAssistant import RagAssistant
 
 
 def load_template():


### PR DESCRIPTION
fixed the following errors

```
$ rag_assistant
Subclass Parameter does not have a type annotation
{'temperature_in_fahrenheit': '77.0'}
{'temperature_in_celsius': '-273.15'}
{'temperature_in_kelvin': '273.15'}
/home/johnmkagunda/.local/lib/python3.10/site-packages/pydantic/_internal/_config.py:341: UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'populate_by_name'
* 'smart_union' has been removed
  warnings.warn(message, UserWarning)
Traceback (most recent call last):
  File "/home/johnmkagunda/miniconda3/envs/py310/bin/rag_assistant", line 5, in <module>
    from rag_assistant.main import main
  File "/home/johnmkagunda/miniconda3/envs/py310/lib/python3.10/site-packages/rag_assistant/main.py", line 2, in <module>
    from rag_assistant.gradio_ui import GradioUI
  File "/home/johnmkagunda/miniconda3/envs/py310/lib/python3.10/site-packages/rag_assistant/gradio_ui.py", line 5, in <module>
    from gradio_tabs.chat_tab import ChatTab
ModuleNotFoundError: No module named 'gradio_tabs'
```